### PR TITLE
Add Dates to Status Tables

### DIFF
--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -7,7 +7,7 @@ class ModelsController < ApplicationController
 
     models_by_type = @models.group_by(&:subclass_name)
     statuses = ModelStatusQuery.new( @models.pluck(:genome_model_id) ).execute
-    @table_items = @models.page(params[:page])
+    @table_items = @models.order(:creation_date).page(params[:page])
 
     model_status_hash = @table_items.each_with_object({}) do |item, hash|
       hash[item.id] = { model: item }
@@ -26,7 +26,7 @@ class ModelsController < ApplicationController
 
   def status
     @model = Model.with_statuses_scope.where(genome_model_id: params[:id]).first!
-    builds = @model.builds
+    builds = @model.builds.order(:created_at)
 
     @analysis_project = @model.analysis_projects.first
 

--- a/app/presenters/build_status_table.rb
+++ b/app/presenters/build_status_table.rb
@@ -9,7 +9,7 @@ class BuildStatusTable < StatusTable
   private
   def get_table_items(builds)
     builds.map do |build|
-      StatusTableItem.new(build.id, build.model.name, build.status, build_status_path(id: build.build_id))
+      StatusTableItem.new(build.id, build.model.name, build.created_at, build.status, build_status_path(id: build.build_id))
     end
   end
 end

--- a/app/presenters/model_status_table.rb
+++ b/app/presenters/model_status_table.rb
@@ -9,7 +9,7 @@ class ModelStatusTable < StatusTable
   private
   def get_table_items(models_with_status)
     models_with_status.map do |id, data|
-      StatusTableItem.new(id, data[:model].name, data[:status], model_status_path(id: id))
+      StatusTableItem.new(id, data[:model].name, data[:model].creation_date, data[:status], model_status_path(id: id))
     end
   end
 end

--- a/app/presenters/status_table.rb
+++ b/app/presenters/status_table.rb
@@ -8,5 +8,5 @@ class StatusTable
   end
 end
 
-class StatusTableItem < Struct.new(:id, :name, :status, :uri)
+class StatusTableItem < Struct.new(:id, :name, :date, :status, :uri)
 end

--- a/app/views/shared/_status_table.html.haml
+++ b/app/views/shared/_status_table.html.haml
@@ -2,6 +2,7 @@
   %thead
     %tr
       %th ID
+      %th Date
       %th Status
       %th Name
   %tbody
@@ -9,6 +10,8 @@
     %tr
       %td
         = link_to(item.id, item.uri)
+      %td
+        = item.date
       %td.text-center
         = item.status
       %td


### PR DESCRIPTION
This adds a date column in the "status tables" for builds and models.  Additionally, the tables are now explicitly sorted by when the models/builds were created.

Closes #3 and #4.
